### PR TITLE
Fix broken image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@
             <a href="https://gunicorn.org/" target="_blank" rel="noopener noreferrer">
                 <img height="32" width="32" src="https://cdn.simpleicons.org/gunicorn" alt="Gunicorn" />
             </a>
-            <a href="https://scrapy.org/" target="_blank" rel="noopener noreferrer"> 
-                <img height="32" width="32" src="/scrapylogo.png" alt="Scrapy" /> 
+            <a href="https://scrapy.org/" target="_blank" rel="noopener noreferrer">
+                <img height="32" width="32" src="./scrapylogo.png" alt="Scrapy" />
             </a>
             <a href="https://www.crummy.com/software/BeautifulSoup/" target="_blank" rel="noopener noreferrer">
                 <img height="32" width="32" src="https://play-lh.googleusercontent.com/yMjUC6LBh7uOCK6wUcIEf5MHZQmSqDPXoInOQLZzw0DWQsPJuvkwSymX2zI4Ok7i_BY" alt="Beautiful Soup" />


### PR DESCRIPTION
## Summary
- fix the Scrapy logo link in README to use a relative path

## Testing
- `yamllint .github/workflows/waka-readme.yml`
- `yamllint .github/workflows/update-readme.yml`
- `yamllint .github/workflows/github-snake.yml`


------
https://chatgpt.com/codex/tasks/task_e_6840433d3260832db816c951b19a14b7