### PR TITLE
Fix YAML lint issues

### DIFF
--- a/.github/workflows/github-snake.yml
+++ b/.github/workflows/github-snake.yml
@@ -10,11 +10,11 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    # Steps executed as part of the job
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
-    
+
       - name: Generate the snake files in './dist/'
         uses: Platane/snk@v3
         with:
@@ -24,7 +24,7 @@ jobs:
             dist/github-snake-dark.svg?palette=github-dark
             dist/ocean.gif?color_snake=orange&color_dots=#bfd6f6,#8dbdff,#64a1f4,#4b91f1,#3c7dd9
         env:
-           GITHUB_TOKEN: ${{ secrets.GH_SNAKE }}
+          GITHUB_TOKEN: ${{ secrets.GH_SNAKE }}
 
       - name: Show build status
         run: git status


### PR DESCRIPTION
## Summary
- remove trailing spaces in the `github-snake` workflow
- clean up indentation and shorten a long comment

## Testing
- `yamllint .github/workflows/github-snake.yml`
- `yamllint .github/workflows/update-readme.yml .github/workflows/waka-readme.yml`
- `markdownlint README.md` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_684058a800f4832da012fe36d497c9ef